### PR TITLE
Change grib2 string to FV3GFS NEMSIO for ICs and LBCs.

### DIFF
--- a/sorc/chgres_cube.fd/write_data.F90
+++ b/sorc/chgres_cube.fd/write_data.F90
@@ -538,7 +538,7 @@
    elseif (trim(input_type) == "gaussian_netcdf") then
      error = nf90_put_att(ncid, nf90_global, 'source', 'FV3GFS GAUSSIAN NETCDF FILE')
    elseif (trim(input_type) == "grib2") then
-     error = nf90_put_att(ncid, nf90_global, 'source', 'FV3GFS GRIB2 FILE')
+     error = nf90_put_att(ncid, nf90_global, 'source', 'FV3GFS GAUSSIAN NEMSIO FILE')
    endif
 
    error = nf90_enddef(ncid, header_buffer_val,4,0,4)
@@ -1327,7 +1327,7 @@
    elseif (trim(input_type) == "restart") then
      error = nf90_put_att(ncid, nf90_global, 'source', 'FV3GFS TILED RESTART FILE')
    elseif (trim(input_type) == "grib2") then
-     error = nf90_put_att(ncid, nf90_global, 'source', 'FV3GFS GRIB2 FILE')
+     error = nf90_put_att(ncid, nf90_global, 'source', 'FV3GFS GAUSSIAN NEMSIO FILE')
    endif
 
 !--- define field


### PR DESCRIPTION
Change grib2 string (from FV3GFS GRIB2 FILE to FV3GFS GAUSSIAN NEMSIO) when writing out netCDF IC and LBC files with chgres_cube.  This fix is required at the moment for the FV3 dycore to correctly initialize hydrometeor fields and avoid modifications/adjustments to specific fields (see [Issue 97](https://github.com/ufs-community/ufs-weather-model/issues/97) in the authoritative ufs-weather-model repository for more info).